### PR TITLE
Fix ITAPI action registration

### DIFF
--- a/Applications/ShipApplication.cs
+++ b/Applications/ShipApplication.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using InteractiveTerminalAPI.UI;
 using InteractiveTerminalAPI.UI.Application;
 using InteractiveTerminalAPI.UI.Cursor;
@@ -490,7 +490,7 @@ public class ShipApplication : PageApplication
             if (randomObj is ItemData data)
                 ChuteInteract.Instance?.SpawnItemServerRpc(data);
 
-            UnityEngine.Object.Destroy(InteractiveTerminalManager.Instance);
+            MainScreen(2);
         }, () => MainScreen(2));
     }
 
@@ -526,7 +526,7 @@ public class ShipApplication : PageApplication
                 );
             }
             
-            UnityEngine.Object.Destroy(InteractiveTerminalManager.Instance);
+            MainScreen(3);
         }, () => MainScreen(3));
     }
 

--- a/Applications/ShipApplication.cs
+++ b/Applications/ShipApplication.cs
@@ -82,6 +82,7 @@ public class ShipApplication : PageApplication
 
     private void RegisterExitAction(System.Action<CallbackContext> action)
     {
+        UnregisterExitAction();
         LastExitPerformedAction = action;
         InteractiveTerminalAPI.Compat.InputUtils_Compat.CursorExitKey.performed -= OnScreenExit;
         InteractiveTerminalAPI.Compat.InputUtils_Compat.CursorExitKey.performed += action;

--- a/Applications/ShipApplication.cs
+++ b/Applications/ShipApplication.cs
@@ -90,12 +90,15 @@ public class ShipApplication : PageApplication
 
     private void UnregisterExitAction()
     {
-        InteractiveTerminalAPI.Compat.InputUtils_Compat.CursorExitKey.performed -= LastExitPerformedAction;
+        if (LastExitPerformedAction != null)
+        {
+            InteractiveTerminalAPI.Compat.InputUtils_Compat.CursorExitKey.performed -= LastExitPerformedAction;
+            LastExitPerformedAction = null;
+        }
         // If OnScreenExit is not already registered, this is a no-op
         // Ensures OnScreenExit is never double-registered
         InteractiveTerminalAPI.Compat.InputUtils_Compat.CursorExitKey.performed -= OnScreenExit;
         InteractiveTerminalAPI.Compat.InputUtils_Compat.CursorExitKey.performed += OnScreenExit;
-        LastExitPerformedAction = null;
     }
 
     private BoxedScreen CreateScreen(string title, ITextElement[] elements)


### PR DESCRIPTION
Fixes #21 

Specifically, the fix is in cc575523ec30cee73651e71c2313dafe40004acb, while the other two commits are future-proofing so that the accidentally calling a method at the wrong time (or forgetting to call one) doesn't break the menu.